### PR TITLE
Fixes for different issues with CLOBs

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -1,0 +1,19 @@
+name: .NET Core
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 2.2.108
+    - name: Build with dotnet
+      run: dotnet build --configuration Release
+    - name: Test with dotnet
+      run: dotnet test --configuration Release

--- a/IonDotnet.Tests/Common/DirStructure.cs
+++ b/IonDotnet.Tests/Common/DirStructure.cs
@@ -8,7 +8,7 @@ namespace IonDotnet.Tests.Common
         private static DirectoryInfo GetRootDir()
         {
             var dirInfo = new DirectoryInfo(Directory.GetCurrentDirectory());
-            while (!string.Equals(dirInfo.Name, "iondotnet", StringComparison.OrdinalIgnoreCase))
+            while (!string.Equals(dirInfo.Name, "ion-dotnet", StringComparison.OrdinalIgnoreCase))
             {
                 dirInfo = Directory.GetParent(dirInfo.FullName);
             }

--- a/IonDotnet.Tests/Integration/Vector.cs
+++ b/IonDotnet.Tests/Integration/Vector.cs
@@ -31,7 +31,9 @@ namespace IonDotnet.Tests.Integration
         private static readonly DirectoryInfo IonTestDir = DirStructure.IonTestDir();
         private static readonly DirectoryInfo GoodDir = IonTestDir.GetDirectories("good").First();
         private static readonly DirectoryInfo GoodTimestampDir = IonTestDir.GetDirectories("good/timestamp").First();
+        private static readonly DirectoryInfo GoodTimestampEquivDir = IonTestDir.GetDirectories("good/timestamp/equivTimeline").First();
         private static readonly DirectoryInfo GoodEquivDir = IonTestDir.GetDirectories("good/equivs").First();
+        private static readonly DirectoryInfo GoodEquivUtf8Dir = IonTestDir.GetDirectories("good/equivs/utf8").First();
         private static readonly DirectoryInfo GoodNonEquivDir = IonTestDir.GetDirectories("good/non-equivs").First();
 
         private static IEnumerable<FileInfo> GetIonFiles(DirectoryInfo dirInfo)
@@ -53,9 +55,21 @@ namespace IonDotnet.Tests.Integration
                 .Select(f => new[] {f});
         }
 
+        public static IEnumerable<object[]> GoodTimestampEquivFiles()
+        {
+            return GetIonFiles(GoodTimestampEquivDir)
+                .Select(f => new[] {f});
+        }
+
         public static IEnumerable<object[]> GoodEquivFiles()
         {
             return GetIonFiles(GoodEquivDir)
+                .Select(f => new[] {f});
+        }
+
+        public static IEnumerable<object[]> GoodEquivUtf8Files()
+        {
+            return GetIonFiles(GoodEquivUtf8Dir)
                 .Select(f => new[] {f});
         }
 
@@ -67,7 +81,7 @@ namespace IonDotnet.Tests.Integration
 
         public static string TestCaseName(MethodInfo methodInfo, object[] data)
         {
-            var fileFullName = ((FileInfo) data[0]).FullName;
+            var fileFullName = ((FileInfo)data[0]).FullName;
             var testDirIdx = fileFullName.IndexOf(IonTestDir.FullName, StringComparison.OrdinalIgnoreCase);
             return fileFullName.Substring(testDirIdx + IonTestDir.FullName.Length);
         }
@@ -78,7 +92,9 @@ namespace IonDotnet.Tests.Integration
         [TestMethod]
         [DynamicData(nameof(GoodFiles), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(TestCaseName))]
         [DynamicData(nameof(GoodTimestampFiles), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(TestCaseName))]
+        [DynamicData(nameof(GoodTimestampEquivFiles), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(TestCaseName))]
         [DynamicData(nameof(GoodEquivFiles), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(TestCaseName))]
+        [DynamicData(nameof(GoodEquivUtf8Files), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(TestCaseName))]
         [DynamicData(nameof(GoodNonEquivFiles), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(TestCaseName))]
         public void LoadGood_Successful(FileInfo fi)
         {
@@ -88,6 +104,10 @@ namespace IonDotnet.Tests.Integration
         [TestMethod]
         [DynamicData(nameof(GoodFiles), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(TestCaseName))]
         [DynamicData(nameof(GoodTimestampFiles), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(TestCaseName))]
+        [DynamicData(nameof(GoodTimestampEquivFiles), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(TestCaseName))]
+        [DynamicData(nameof(GoodEquivFiles), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(TestCaseName))]
+        [DynamicData(nameof(GoodEquivUtf8Files), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(TestCaseName))]
+        [DynamicData(nameof(GoodNonEquivFiles), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(TestCaseName))]
         public void LoadGood_RoundTrip(FileInfo fi)
         {
             var datagram = LoadFile(fi, out var readerTable);

--- a/IonDotnet.Tests/Integration/VectorBad.cs
+++ b/IonDotnet.Tests/Integration/VectorBad.cs
@@ -65,7 +65,7 @@ namespace IonDotnet.Tests.Integration
         [DynamicData(nameof(BadUtf8Files), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(TestCaseName))]
         [DynamicData(nameof(BadTimestamp), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(TestCaseName))]
         [DynamicData(nameof(BadOutOfRangeTimestamp), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(TestCaseName))]
-        public void LoadBad_RoundTrip(FileInfo fi)
+        public void LoadBad(FileInfo fi)
         {
             IonLoader.WithReaderOptions(new ReaderOptions { Format = ReaderFormat.Text }).Load(fi);
         }

--- a/IonDotnet.Tests/Integration/VectorBad.cs
+++ b/IonDotnet.Tests/Integration/VectorBad.cs
@@ -67,7 +67,6 @@ namespace IonDotnet.Tests.Integration
         [DynamicData(nameof(BadOutOfRangeTimestamp), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(TestCaseName))]
         public void LoadBad_RoundTrip(FileInfo fi)
         {
-            Console.WriteLine("aaa " + fi.FullName);
             IonLoader.WithReaderOptions(new ReaderOptions { Format = ReaderFormat.Text }).Load(fi);
         }
     }

--- a/IonDotnet.Tests/Integration/VectorBad.cs
+++ b/IonDotnet.Tests/Integration/VectorBad.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using IonDotnet.Systems;
 using IonDotnet.Tests.Common;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -10,84 +12,63 @@ namespace IonDotnet.Tests.Integration
     [TestClass]
     public class VectorBad
     {
+        private static readonly HashSet<string> Excludes = new HashSet<string>
+        {
+            "clobWithLongLiteralInlineCommentAtEnd.ion"
+        };
+
         private static readonly DirectoryInfo IonTestDir = DirStructure.IonTestDir();
         private static readonly DirectoryInfo BadDir = IonTestDir.GetDirectories("bad").First();
+        private static readonly DirectoryInfo BadUtf8Dir = IonTestDir.GetDirectories("bad/utf8").First();
+        private static readonly DirectoryInfo BadTimestampDir = IonTestDir.GetDirectories("bad/timestamp").First();
+        private static readonly DirectoryInfo BadOutOfRangeDir = IonTestDir.GetDirectories("bad/timestamp/outOfRange").First();
 
-        private static FileInfo GetFile(DirectoryInfo dir, string name)
+        private static IEnumerable<FileInfo> GetIonFiles(DirectoryInfo dirInfo)
+           => dirInfo.GetFiles()
+           .Where(f => !Excludes.Contains(f.Name)
+                       && f.Name.EndsWith(".ion") || f.Name.EndsWith(".10n"));
+
+        public static IEnumerable<object[]> BadFiles()
         {
-            return new FileInfo(Path.Combine(dir.FullName, name));
+            return GetIonFiles(BadDir)
+                .Select(f => new[] { f });
         }
 
-        [DataRow("annotationFalse.ion")]
-        [DataRow("annotationNan.ion")]
-        [DataRow("annotationNull.ion")]
-        [DataRow("annotationNullInt.ion")]
-        [DataRow("annotationSymbolIDUnmapped.ion")]
-        [DataRow("annotationTrue.ion")]
-        [DataRow("annotationWithoutValue.ion")]
-        [TestMethod]
-        [ExpectedException(typeof(IonException), AllowDerivedTypes = true)]
-        public void Text_InvalidAnnotation(string fileName)
+        public static IEnumerable<object[]> BadUtf8Files()
         {
-            var fileInfo = GetFile(BadDir, fileName);
-            IonLoader.WithReaderOptions(new ReaderOptions {Format = ReaderFormat.Text}).Load(fileInfo);
+            return GetIonFiles(BadUtf8Dir)
+                .Select(f => new[] { f });
         }
 
-        [DataRow("int_1.ion")]
-        [DataRow("int_2.ion")]
-        [DataRow("int_3.ion")]
-        [DataRow("int_6.ion")]
-        [DataRow("int_7.ion")]
-        [DataRow("int_8.ion")]
-        [DataRow("int_9.ion")]
-        [DataRow("int_10.ion")]
-        [TestMethod]
-        [ExpectedException(typeof(FormatException), AllowDerivedTypes = true)]
-        public void Int_Invalid(string fileName)
+        public static IEnumerable<object[]> BadTimestamp()
         {
-            var fileInfo = GetFile(BadDir, fileName);
-            IonLoader.WithReaderOptions(new ReaderOptions {Format = ReaderFormat.Text}).Load(fileInfo);
+            return GetIonFiles(BadTimestampDir)
+                .Select(f => new[] { f });
         }
 
-        [DataRow("float_1.ion")]
-        [DataRow("float_2.ion")]
-        [DataRow("float_3.ion")]
-        [DataRow("float_4.ion")]
-        [DataRow("float_5.ion")]
-        [DataRow("float_6.ion")]
-        [DataRow("float_7.ion")]
-        [DataRow("float_8.ion")]
-        [DataRow("float_9.ion")]
-        [DataRow("float_10.ion")]
-        [DataRow("float_11.ion")]
-        [TestMethod]
-        [ExpectedException(typeof(FormatException), AllowDerivedTypes = true)]
-        public void Float_Invalid(string fileName)
+        public static IEnumerable<object[]> BadOutOfRangeTimestamp()
         {
-            var fileInfo = GetFile(BadDir, fileName);
-            IonLoader.WithReaderOptions(new ReaderOptions {Format = ReaderFormat.Text}).Load(fileInfo);
+            return GetIonFiles(BadOutOfRangeDir)
+                .Select(f => new[] { f });
         }
-        
-        [DataRow("decimal_1.ion")]
-        [DataRow("decimal_2.ion")]
-        [DataRow("decimal_3.ion")]
-        [DataRow("decimal_4.ion")]
-        [DataRow("decimal_5.ion")]
-        [DataRow("decimal_6.ion")]
-        [DataRow("decimal_7.ion")]
-        [DataRow("decimal_8.ion")]
-        [DataRow("decimal_9.ion")]
-        [DataRow("decimal_10.ion")]
-        [DataRow("decimal_11.ion")]
-        [DataRow("decimal_12.ion")]
-        [DataRow("decimal_13.ion")]
-        [DataRow("decimal_14.ion")]
-        [TestMethod]
-        [ExpectedException(typeof(FormatException), AllowDerivedTypes = true)]
-        public void Decimal_Invalid(string fileName)
+
+        public static string TestCaseName(MethodInfo methodInfo, object[] data)
         {
-            var fileInfo = GetFile(BadDir, fileName);
-            IonLoader.WithReaderOptions(new ReaderOptions {Format = ReaderFormat.Text}).Load(fileInfo);
+            var fileFullName = ((FileInfo)data[0]).FullName;
+            var testDirIdx = fileFullName.IndexOf(IonTestDir.FullName, StringComparison.OrdinalIgnoreCase);
+            return fileFullName.Substring(testDirIdx + IonTestDir.FullName.Length);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(Exception), AllowDerivedTypes = true)]
+        [DynamicData(nameof(BadFiles), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(TestCaseName))]
+        [DynamicData(nameof(BadUtf8Files), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(TestCaseName))]
+        [DynamicData(nameof(BadTimestamp), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(TestCaseName))]
+        [DynamicData(nameof(BadOutOfRangeTimestamp), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(TestCaseName))]
+        public void LoadBad_RoundTrip(FileInfo fi)
+        {
+            Console.WriteLine("aaa " + fi.FullName);
+            IonLoader.WithReaderOptions(new ReaderOptions { Format = ReaderFormat.Text }).Load(fi);
         }
     }
 }

--- a/IonDotnet/Internals/Text/SystemTextReader.cs
+++ b/IonDotnet/Internals/Text/SystemTextReader.cs
@@ -454,7 +454,7 @@ namespace IonDotnet.Internals.Text
             {
                 //lookup symbol string from sid
                 var text = GetSymbolTable().FindKnownSymbol(_v.IntValue);
-                if (text == null && (_v.IntValue > GetSymbolTable().MaxId + 1 || _v.IntValue < 0))
+                if (text == null && (_v.IntValue > GetSymbolTable().MaxId || _v.IntValue < 0))
                 {
                     throw new UnknownSymbolException(_v.IntValue);
                 }

--- a/IonDotnet/Internals/Text/SystemTextReader.cs
+++ b/IonDotnet/Internals/Text/SystemTextReader.cs
@@ -453,7 +453,12 @@ namespace IonDotnet.Internals.Text
             if (_v.TypeSet.HasFlag(ScalarType.Int) && !_v.TypeSet.HasFlag(ScalarType.String))
             {
                 //lookup symbol string from sid
-                _v.AddString(GetSymbolTable().FindKnownSymbol(_v.IntValue));
+                var text = GetSymbolTable().FindKnownSymbol(_v.IntValue);
+                if (text == null && (_v.IntValue > GetSymbolTable().MaxId + 1 || _v.IntValue < 0))
+                {
+                    throw new UnknownSymbolException(_v.IntValue);
+                }
+                _v.AddString(text);
             }
             else if (_v.StringValue != null && !_v.TypeSet.HasFlag(ScalarType.Int))
             {

--- a/IonDotnet/Internals/Text/TextScanner.cs
+++ b/IonDotnet/Internals/Text/TextScanner.cs
@@ -1964,11 +1964,6 @@ namespace IonDotnet.Internals.Text
             while (true)
             {
                 var c = ReadTripleQuotedChar(isClob);
-                // CLOB texts should be only 7-bit ASCII characters
-                if (isClob)
-                {
-                    Required7BitChar(c);
-                }
                 switch (c)
                 {
                     case CharacterSequence.CharSeqStringTerminator:
@@ -2013,6 +2008,11 @@ namespace IonDotnet.Internals.Text
                     //                        sb.Append(Characters.GetHighSurrogate(c));
                     //                        c = Characters.GetLowSurrogate(c);
                     //                    }
+                }
+                else
+                {
+                    // CLOB texts should be only 7-bit ASCII characters
+                    Required7BitChar(c);
                 }
 
                 sb.Append((char)c);

--- a/IonDotnet/Internals/Text/TextScanner.cs
+++ b/IonDotnet/Internals/Text/TextScanner.cs
@@ -992,9 +992,9 @@ namespace IonDotnet.Internals.Text
             {
                 var c = ReadStringChar(Characters.ProhibitionContext.ShortChar);
                 // CLOB texts should be only 7-bit ASCII characters
-                if (isClob && !Characters.Is7BitChar(c))
+                if (isClob)
                 {
-                    throw new IonException($"Illegal character: {(char)c}. All characters must be 7-bit ASCII");
+                    Required7BitChar(c);
                 }
                 switch (c)
                 {
@@ -1964,6 +1964,11 @@ namespace IonDotnet.Internals.Text
             while (true)
             {
                 var c = ReadTripleQuotedChar(isClob);
+                // CLOB texts should be only 7-bit ASCII characters
+                if (isClob)
+                {
+                    Required7BitChar(c);
+                }
                 switch (c)
                 {
                     case CharacterSequence.CharSeqStringTerminator:
@@ -2011,6 +2016,14 @@ namespace IonDotnet.Internals.Text
                 }
 
                 sb.Append((char)c);
+            }
+        }
+
+        private void Required7BitChar(int c)
+        {
+            if (!Characters.Is7BitChar(c))
+            {
+                throw new IonException($"Illegal character: {(char)c}. All characters must be 7-bit ASCII");
             }
         }
 

--- a/IonDotnet/Utils/Characters.cs
+++ b/IonDotnet/Utils/Characters.cs
@@ -175,8 +175,8 @@ namespace IonDotnet.Utils
 //            return (char) ((c | LowSurrogate) & 0xffff);
 //        }
 
-//        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-//        public static bool Is7BitChar(int c) => (c & ~0x7f) == 0;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool Is7BitChar(int c) => (c & ~0x7f) == 0;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool Is8BitChar(int c) => (c & ~0xff) == 0;


### PR DESCRIPTION
*Issues with CLOBs*

*Description of changes:*
This pull request mainly addresses the following points:
- clob can contain only 7-bit ASCII characters
- clobs cannot have any comments within the value
- only 1 pair of double quoted value can exist in a clob. eg: {{ "a" "b" }} is not allowed
- multiple ''' values can combine in one clobs, however only ''' values can be defined in such clobs. In other words, '''a''' and "b" cannot be in the same clob.