### PR TITLE
Enabling an instance of a Tree class to a second container - Making scalar types immutable

### DIFF
--- a/IonDotnet.Tests/Internals/TreeReaderTest.cs
+++ b/IonDotnet.Tests/Internals/TreeReaderTest.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Numerics;
-using IonDotnet.Internals.Binary;
 using IonDotnet.Internals.Tree;
 using IonDotnet.Tests.Common;
 using IonDotnet.Tree;

--- a/IonDotnet.Tests/Tree/IonBoolTest.cs
+++ b/IonDotnet.Tests/Tree/IonBoolTest.cs
@@ -28,8 +28,6 @@ namespace IonDotnet.Tests.Tree
             Assert.AreEqual(IonType.Bool, v.Type());
             Assert.IsFalse(v.IsNull);
             Assert.AreEqual(value, v.BoolValue);
-            v.BoolValue = !value;
-            Assert.AreEqual(!value, v.BoolValue);
         }
 
         [DataRow(true)]
@@ -42,7 +40,6 @@ namespace IonDotnet.Tests.Tree
             Assert.IsFalse(v.IsReadOnly);
             v.MakeReadOnly();
             Assert.IsTrue(v.IsReadOnly);
-            Assert.ThrowsException<InvalidOperationException>(() => v.BoolValue = value != true);
             Assert.ThrowsException<InvalidOperationException>(() => v.AddTypeAnnotation("something"));
             Assert.ThrowsException<InvalidOperationException>(() => v.MakeNull());
         }

--- a/IonDotnet.Tests/Tree/IonContainerTest.cs
+++ b/IonDotnet.Tests/Tree/IonContainerTest.cs
@@ -71,7 +71,7 @@ namespace IonDotnet.Tests.Tree
             foreach (var c in v)
             {
                 Assert.IsTrue(v.Contains(c));
-                Assert.AreEqual(c.Container, v);
+                //Assert.AreEqual(c.Container, v);
             }
 
             //clear
@@ -79,7 +79,7 @@ namespace IonDotnet.Tests.Tree
             foreach (var c in list)
             {
                 Assert.IsFalse(v.Contains(c));
-                Assert.IsNull(c.Container);
+                //Assert.IsNull(c.Container);
             }
         }
 
@@ -105,7 +105,7 @@ namespace IonDotnet.Tests.Tree
             foreach (var c in list)
             {
                 Assert.IsFalse(v.Contains(c));
-                Assert.IsNull(c.Container);
+                //Assert.IsNull(c.Container);
             }
         }
 
@@ -140,15 +140,15 @@ namespace IonDotnet.Tests.Tree
                 DoAdd(v, c);
             }
 
-            Assert.AreEqual(v, r?.Container);
+            //Assert.AreEqual(v, r?.Container);
             Assert.IsTrue(v.Contains(r));
             v.Remove(r);
-            Assert.IsNull(r?.Container);
+            //Assert.IsNull(r?.Container);
             Assert.AreEqual(count - 1, v.Count);
         }
 
         [ExpectedException(typeof(ContainedValueException))]
-        [TestMethod]
+        [TestMethod][Ignore]
         public void AddChildOfAnotherContainer()
         {
             var v1 = MakeMutableValue() as IonContainer;

--- a/IonDotnet.Tests/Tree/IonContainerTest.cs
+++ b/IonDotnet.Tests/Tree/IonContainerTest.cs
@@ -71,7 +71,6 @@ namespace IonDotnet.Tests.Tree
             foreach (var c in v)
             {
                 Assert.IsTrue(v.Contains(c));
-                //Assert.AreEqual(c.Container, v);
             }
 
             //clear
@@ -79,7 +78,6 @@ namespace IonDotnet.Tests.Tree
             foreach (var c in list)
             {
                 Assert.IsFalse(v.Contains(c));
-                //Assert.IsNull(c.Container);
             }
         }
 
@@ -105,7 +103,6 @@ namespace IonDotnet.Tests.Tree
             foreach (var c in list)
             {
                 Assert.IsFalse(v.Contains(c));
-                //Assert.IsNull(c.Container);
             }
         }
 
@@ -140,10 +137,8 @@ namespace IonDotnet.Tests.Tree
                 DoAdd(v, c);
             }
 
-            //Assert.AreEqual(v, r?.Container);
             Assert.IsTrue(v.Contains(r));
             v.Remove(r);
-            //Assert.IsNull(r?.Container);
             Assert.AreEqual(count - 1, v.Count);
         }
     }

--- a/IonDotnet.Tests/Tree/IonContainerTest.cs
+++ b/IonDotnet.Tests/Tree/IonContainerTest.cs
@@ -146,16 +146,5 @@ namespace IonDotnet.Tests.Tree
             //Assert.IsNull(r?.Container);
             Assert.AreEqual(count - 1, v.Count);
         }
-
-        [ExpectedException(typeof(ContainedValueException))]
-        [TestMethod][Ignore]
-        public void AddChildOfAnotherContainer()
-        {
-            var v1 = MakeMutableValue() as IonContainer;
-            var item = (IonValue) MakeMutableValue();
-            var v2 = MakeMutableValue() as IonContainer;
-            DoAdd(v1, item);
-            DoAdd(v2, item);
-        }
     }
 }

--- a/IonDotnet.Tests/Tree/IonFloatTest.cs
+++ b/IonDotnet.Tests/Tree/IonFloatTest.cs
@@ -32,9 +32,6 @@ namespace IonDotnet.Tests.Tree
             Assert.AreEqual(IonType.Float, v.Type());
             Assert.IsFalse(v.IsNull);
             Assert.AreEqual(value, v.DoubleValue);
-
-            v.DoubleValue = 1.0 + value;
-            Assert.AreEqual(1.0 + value, v.DoubleValue);
         }
 
         [DataRow(null)]
@@ -48,7 +45,6 @@ namespace IonDotnet.Tests.Tree
             Assert.IsFalse(v.IsReadOnly);
             v.MakeReadOnly();
             Assert.IsTrue(v.IsReadOnly);
-            Assert.ThrowsException<InvalidOperationException>(() => v.DoubleValue = 0.5);
             Assert.ThrowsException<InvalidOperationException>(() => v.AddTypeAnnotation("something"));
             Assert.ThrowsException<InvalidOperationException>(() => v.MakeNull());
         }

--- a/IonDotnet.Tests/Tree/IonIntTest.cs
+++ b/IonDotnet.Tests/Tree/IonIntTest.cs
@@ -41,9 +41,6 @@ namespace IonDotnet.Tests.Tree
             var v = new IonInt(value);
             Assert.IsFalse(v.IsNull);
             AssertEqual(v, value);
-
-            v.IntValue = 10;
-            AssertEqual(v, 10);
         }
 
         [DataRow((long) int.MinValue - 10)]
@@ -63,9 +60,6 @@ namespace IonDotnet.Tests.Tree
             var v = new IonInt(value);
             Assert.IsFalse(v.IsNull);
             AssertEqual(v, value);
-
-            v.LongValue = long.MaxValue - 1000;
-            AssertEqual(v, long.MaxValue - 1000);
         }
 
         [TestMethod]
@@ -81,9 +75,6 @@ namespace IonDotnet.Tests.Tree
             b1 = b1 + 1000;
             var v = new IonInt(b1);
             AssertEqual(v, b1);
-            var b2 = b1 + 1000;
-            v.BigIntegerValue = b2;
-            AssertEqual(v, b2);
         }
 
         [TestMethod]
@@ -94,7 +85,6 @@ namespace IonDotnet.Tests.Tree
             v.MakeReadOnly();
             Assert.IsTrue(v.IsReadOnly);
 
-            Assert.ThrowsException<InvalidOperationException>(() => v.IntValue = 10);
             Assert.ThrowsException<InvalidOperationException>(() => v.AddTypeAnnotation("something"));
             Assert.ThrowsException<InvalidOperationException>(() => v.MakeNull());
         }

--- a/IonDotnet.Tests/Tree/IonSequenceTest.cs
+++ b/IonDotnet.Tests/Tree/IonSequenceTest.cs
@@ -48,7 +48,7 @@ namespace IonDotnet.Tests.Tree
             }
 
             v.Insert(idx, r);
-            Assert.AreEqual(v, r.Container);
+            //Assert.AreEqual(v, r.Container);
             Assert.AreEqual(count + 1, v.Count);
             Assert.AreEqual(idx, v.IndexOf(r));
         }
@@ -71,7 +71,7 @@ namespace IonDotnet.Tests.Tree
             var r = v[idx];
             v.RemoveAt(idx);
             Assert.AreEqual(count - 1, v.Count);
-            Assert.IsNull(r.Container);
+            //Assert.IsNull(r.Container);
         }
 
         [TestMethod]

--- a/IonDotnet.Tests/Tree/IonSequenceTest.cs
+++ b/IonDotnet.Tests/Tree/IonSequenceTest.cs
@@ -48,7 +48,6 @@ namespace IonDotnet.Tests.Tree
             }
 
             v.Insert(idx, r);
-            //Assert.AreEqual(v, r.Container);
             Assert.AreEqual(count + 1, v.Count);
             Assert.AreEqual(idx, v.IndexOf(r));
         }
@@ -71,7 +70,6 @@ namespace IonDotnet.Tests.Tree
             var r = v[idx];
             v.RemoveAt(idx);
             Assert.AreEqual(count - 1, v.Count);
-            //Assert.IsNull(r.Container);
         }
 
         [TestMethod]

--- a/IonDotnet.Tests/Tree/IonStringTest.cs
+++ b/IonDotnet.Tests/Tree/IonStringTest.cs
@@ -29,9 +29,6 @@ namespace IonDotnet.Tests.Tree
             Assert.AreEqual(IonType.String, v.Type());
             Assert.IsFalse(v.IsNull);
             Assert.AreEqual(value, v.StringValue);
-
-            v.StringValue = value2;
-            Assert.AreEqual(value2, v.StringValue);
         }
 
         [DataRow(null)]
@@ -44,8 +41,6 @@ namespace IonDotnet.Tests.Tree
             Assert.IsFalse(v.IsReadOnly);
             v.MakeReadOnly();
             Assert.IsTrue(v.IsReadOnly);
-            Assert.ThrowsException<InvalidOperationException>(() => v.StringValue = "something else");
-            Assert.ThrowsException<InvalidOperationException>(() => v.StringValue = null);
             Assert.ThrowsException<InvalidOperationException>(() => v.AddTypeAnnotation("abc"));
             Assert.ThrowsException<InvalidOperationException>(() => v.MakeNull());
         }

--- a/IonDotnet.Tests/Tree/IonStructTest.cs
+++ b/IonDotnet.Tests/Tree/IonStructTest.cs
@@ -41,7 +41,7 @@ namespace IonDotnet.Tests.Tree
             v[field] = c1;
             Assert.AreEqual(1, v.Count);
             Assert.IsTrue(v.ContainsField(field));
-            Assert.AreEqual(c1.Container, v);
+            //Assert.AreEqual(c1.Container, v);
             Assert.IsTrue(v.Contains(c1));
             Assert.AreEqual(c1, v[field]);
 
@@ -49,7 +49,7 @@ namespace IonDotnet.Tests.Tree
             v[field] = c2;
             Assert.AreEqual(1, v.Count);
             Assert.IsFalse(v.Contains(c1));
-            Assert.IsNull(c1.Container);
+            //Assert.IsNull(c1.Container);
             Assert.IsTrue(v.Contains(c2));
             Assert.IsTrue(v.ContainsField(field));
             Assert.AreEqual(c2, v[field]);
@@ -105,7 +105,7 @@ namespace IonDotnet.Tests.Tree
 
             Assert.IsTrue(removed);
             Assert.AreEqual(0, v.Count);
-            Assert.IsNull(c.Container);
+            //Assert.IsNull(c.Container);
             Assert.IsFalse(v.Contains(c));
             Assert.IsFalse(v.RemoveField(field));
         }
@@ -119,7 +119,7 @@ namespace IonDotnet.Tests.Tree
             v[field] = c;
             v.Remove(c);
             Assert.AreEqual(0, v.Count);
-            Assert.IsNull(c.Container);
+            //Assert.IsNull(c.Container);
             Assert.IsFalse(v.Contains(c));
         }
 

--- a/IonDotnet.Tests/Tree/IonStructTest.cs
+++ b/IonDotnet.Tests/Tree/IonStructTest.cs
@@ -41,7 +41,6 @@ namespace IonDotnet.Tests.Tree
             v[field] = c1;
             Assert.AreEqual(1, v.Count);
             Assert.IsTrue(v.ContainsField(field));
-            //Assert.AreEqual(c1.Container, v);
             Assert.IsTrue(v.Contains(c1));
             Assert.AreEqual(c1, v[field]);
 
@@ -49,7 +48,6 @@ namespace IonDotnet.Tests.Tree
             v[field] = c2;
             Assert.AreEqual(1, v.Count);
             Assert.IsFalse(v.Contains(c1));
-            //Assert.IsNull(c1.Container);
             Assert.IsTrue(v.Contains(c2));
             Assert.IsTrue(v.ContainsField(field));
             Assert.AreEqual(c2, v[field]);
@@ -105,7 +103,6 @@ namespace IonDotnet.Tests.Tree
 
             Assert.IsTrue(removed);
             Assert.AreEqual(0, v.Count);
-            //Assert.IsNull(c.Container);
             Assert.IsFalse(v.Contains(c));
             Assert.IsFalse(v.RemoveField(field));
         }
@@ -119,7 +116,6 @@ namespace IonDotnet.Tests.Tree
             v[field] = c;
             v.Remove(c);
             Assert.AreEqual(0, v.Count);
-            //Assert.IsNull(c.Container);
             Assert.IsFalse(v.Contains(c));
         }
 

--- a/IonDotnet/Internals/IonTreeWriter.cs
+++ b/IonDotnet/Internals/IonTreeWriter.cs
@@ -12,8 +12,6 @@ namespace IonDotnet.Internals
     {
         private IIonContainer _currentContainer;
         private Stack<IIonContainer> _containers = new Stack<IIonContainer>();
-        // Holds pairs of  containers, and their respective parents
-        private IDictionary _containersParents = new Dictionary<IIonValue, IIonContainer>();
 
         public IonTreeWriter(IonContainer root)
         {
@@ -172,7 +170,6 @@ namespace IonDotnet.Internals
                     throw new ArgumentOutOfRangeException(nameof(type), type, null);
             }
 
-            _containersParents.Add(c, _containers.Peek());
             _containers.Push(c);
             AppendValue(c);
             _currentContainer = c;
@@ -182,9 +179,8 @@ namespace IonDotnet.Internals
         {
             if (_containers.Count > 0)
             {
-                var c = _containers.Pop();
-                _currentContainer = (IIonContainer)_containersParents[c];
-                _containersParents.Remove(c);
+                _containers.Pop();
+                _currentContainer = _containers.Peek();
             }
             else
             {

--- a/IonDotnet/Internals/Tree/SystemTreeReader.cs
+++ b/IonDotnet/Internals/Tree/SystemTreeReader.cs
@@ -34,7 +34,7 @@ namespace IonDotnet.Internals.Tree
             }
             else
             {
-                _parent = value; // (IIonValue)value.Container; //?
+                _parent = null;
                 _next = value;
             }
         }
@@ -47,7 +47,7 @@ namespace IonDotnet.Internals.Tree
 
         public bool CurrentIsNull => _current.IsNull;
 
-        public bool IsInStruct => CurrentDepth > 0 && _parent.Type() == IonType.Struct;
+        public bool IsInStruct => CurrentDepth > 0 && _parent != null && _parent.Type() == IonType.Struct;
 
         public BigInteger BigIntegerValue()
         {

--- a/IonDotnet/Internals/Tree/SystemTreeReader.cs
+++ b/IonDotnet/Internals/Tree/SystemTreeReader.cs
@@ -34,7 +34,7 @@ namespace IonDotnet.Internals.Tree
             }
             else
             {
-                _parent = (IIonValue)value.Container;
+                _parent = value; // (IIonValue)value.Container; //?
                 _next = value;
             }
         }

--- a/IonDotnet/Tree/IIonBool.cs
+++ b/IonDotnet/Tree/IIonBool.cs
@@ -2,6 +2,6 @@
 {
     public interface IIonBool
     {
-        bool BoolValue { get; set; }
+        bool BoolValue { get; }
     }
 }

--- a/IonDotnet/Tree/IIonContainer.cs
+++ b/IonDotnet/Tree/IIonContainer.cs
@@ -4,7 +4,8 @@ namespace IonDotnet.Tree
 {
     public interface IIonContainer
     {
-        IIonContainer Container { get; set; }
+        //IIonContainer Container { get; set; } //?
+        IIonValue Children { get; } //?
         int Count { get; }
         void Add(IIonValue item);
         void Clear();

--- a/IonDotnet/Tree/IIonContainer.cs
+++ b/IonDotnet/Tree/IIonContainer.cs
@@ -4,8 +4,6 @@ namespace IonDotnet.Tree
 {
     public interface IIonContainer
     {
-        //IIonContainer Container { get; set; } //?
-        IIonValue Children { get; } //?
         int Count { get; }
         void Add(IIonValue item);
         void Clear();

--- a/IonDotnet/Tree/IIonDecimal.cs
+++ b/IonDotnet/Tree/IIonDecimal.cs
@@ -2,7 +2,7 @@
 {
     public interface IIonDecimal
     {
-        decimal DecimalValue { get; set; }
-        BigDecimal BigDecimalValue { get; set; }
+        decimal DecimalValue { get; }
+        BigDecimal BigDecimalValue { get; }
     }
 }

--- a/IonDotnet/Tree/IIonFloat.cs
+++ b/IonDotnet/Tree/IIonFloat.cs
@@ -2,6 +2,6 @@
 {
     public interface IIonFloat
     {
-        double DoubleValue { get; set; }
+        double DoubleValue { get; }
     }
 }

--- a/IonDotnet/Tree/IIonInt.cs
+++ b/IonDotnet/Tree/IIonInt.cs
@@ -5,8 +5,8 @@ namespace IonDotnet.Tree
     public interface IIonInt
     {
         IntegerSize IntegerSize { get; }
-        BigInteger BigIntegerValue { get; set; }
-        int IntValue { get; set; }
-        long LongValue { get; set; }
+        BigInteger BigIntegerValue { get; }
+        int IntValue { get; }
+        long LongValue { get; }
     }
 }

--- a/IonDotnet/Tree/IIonSymbol.cs
+++ b/IonDotnet/Tree/IIonSymbol.cs
@@ -2,6 +2,6 @@
 {
     public interface IIonSymbol : IIonText
     {
-        SymbolToken SymbolValue { get; set; }
+        SymbolToken SymbolValue { get; }
     }
 }

--- a/IonDotnet/Tree/IIonText.cs
+++ b/IonDotnet/Tree/IIonText.cs
@@ -2,6 +2,6 @@
 {
     public interface IIonText
     {
-        string StringValue { get; set; }
+        string StringValue { get; }
     }
 }

--- a/IonDotnet/Tree/IIonTimestamp.cs
+++ b/IonDotnet/Tree/IIonTimestamp.cs
@@ -2,6 +2,6 @@
 {
     public interface IIonTimestamp
     {
-        Timestamp TimestampValue { get; set; }
+        Timestamp TimestampValue { get; }
     }
 }

--- a/IonDotnet/Tree/Impl/IonBool.cs
+++ b/IonDotnet/Tree/Impl/IonBool.cs
@@ -46,12 +46,6 @@ namespace IonDotnet.Tree.Impl
                 ThrowIfNull();
                 return BoolTrueFlagOn();
             }
-            set
-            {
-                ThrowIfLocked();
-                NullFlagOn(false);
-                BoolTrueFlagOn(value);
-            }
         }
 
         /// <summary>

--- a/IonDotnet/Tree/Impl/IonDatagram.cs
+++ b/IonDotnet/Tree/Impl/IonDatagram.cs
@@ -21,11 +21,11 @@ namespace IonDotnet.Tree.Impl
 
         public override IonType Type() => IonType.Datagram;
 
-        public override IIonContainer Container
-        {
-            get => null;
-            set => throw new InvalidOperationException("Cannot set the container of an Ion Datagram");
-        }
+        //public override IIonContainer Container //?
+        //{
+        //    get => null;
+        //    set => throw new InvalidOperationException("Cannot set the container of an Ion Datagram");
+        //}
 
         /// <summary>
         /// Adding an item to the datagram will mark the current symbol table.

--- a/IonDotnet/Tree/Impl/IonDatagram.cs
+++ b/IonDotnet/Tree/Impl/IonDatagram.cs
@@ -21,12 +21,6 @@ namespace IonDotnet.Tree.Impl
 
         public override IonType Type() => IonType.Datagram;
 
-        //public override IIonContainer Container //?
-        //{
-        //    get => null;
-        //    set => throw new InvalidOperationException("Cannot set the container of an Ion Datagram");
-        //}
-
         /// <summary>
         /// Adding an item to the datagram will mark the current symbol table.
         /// </summary>

--- a/IonDotnet/Tree/Impl/IonDecimal.cs
+++ b/IonDotnet/Tree/Impl/IonDecimal.cs
@@ -70,11 +70,6 @@ namespace IonDotnet.Tree.Impl
                 ThrowIfNull();
                 return _val.ToDecimal();
             }
-            set
-            {
-                ThrowIfLocked();
-                _val = new BigDecimal(value);
-            }
         }
 
         public override BigDecimal BigDecimalValue
@@ -83,11 +78,6 @@ namespace IonDotnet.Tree.Impl
             {
                 ThrowIfNull();
                 return _val;
-            }
-            set
-            {
-                ThrowIfLocked();
-                _val = value;
             }
         }
 

--- a/IonDotnet/Tree/Impl/IonFloat.cs
+++ b/IonDotnet/Tree/Impl/IonFloat.cs
@@ -66,12 +66,6 @@ namespace IonDotnet.Tree.Impl
                 ThrowIfNull();
                 return _d;
             }
-            set
-            {
-                ThrowIfLocked();
-                NullFlagOn(false);
-                _d = value;
-            }
         }
 
         public override IonType Type() => IonType.Float;

--- a/IonDotnet/Tree/Impl/IonInt.cs
+++ b/IonDotnet/Tree/Impl/IonInt.cs
@@ -18,12 +18,12 @@ namespace IonDotnet.Tree.Impl
 
         public IonInt(long value) : base(false)
         {
-            LongValue = value;
+            SetLongValue(value);
         }
 
         public IonInt(BigInteger value) : base(false)
         {
-            BigIntegerValue = value;
+            SetBigIntegerValue(value);
         }
 
         private IonInt(bool isNull) : base(isNull)
@@ -87,7 +87,6 @@ namespace IonDotnet.Tree.Impl
                     throw new OverflowException($"Size of this {nameof(IonInt)} is {IntegerSize}");
                 return (int) _longValue;
             }
-            set => LongValue = value;
         }
 
         public override long LongValue
@@ -100,14 +99,6 @@ namespace IonDotnet.Tree.Impl
 
                 return _longValue;
             }
-            set
-            {
-                ThrowIfLocked();
-                NullFlagOn(false);
-                _longValue = value;
-                _bigInteger = null;
-                SetSize(value < int.MinValue || value > int.MaxValue ? IntegerSize.Long : IntegerSize.Int);
-            }
         }
 
         public override BigInteger BigIntegerValue
@@ -116,20 +107,6 @@ namespace IonDotnet.Tree.Impl
             {
                 ThrowIfNull();
                 return _bigInteger ?? new BigInteger(_longValue);
-            }
-            set
-            {
-                ThrowIfLocked();
-                NullFlagOn(false);
-                if (value >= long.MinValue && value <= long.MaxValue)
-                {
-                    LongValue = (long) value;
-                    return;
-                }
-
-                _longValue = 0;
-                _bigInteger = value;
-                SetSize(IntegerSize.BigInteger);
             }
         }
 
@@ -147,10 +124,31 @@ namespace IonDotnet.Tree.Impl
 
         public override IonType Type() => IonType.Int;
 
+        private void SetLongValue(long value)
+        {
+            _longValue = value;
+            _bigInteger = null;
+            SetSize(value < int.MinValue || value > int.MaxValue ? IntegerSize.Long : IntegerSize.Int);
+        }
+
+        private void SetBigIntegerValue(BigInteger value)
+        {
+            if (value >= long.MinValue && value <= long.MaxValue)
+            {
+                SetLongValue((long)value);
+            }
+            else
+            {
+                _longValue = 0;
+                _bigInteger = value;
+                SetSize(IntegerSize.BigInteger);
+            }
+        }
+
         private void SetSize(IntegerSize size)
         {
             Debug.Assert(size != IntegerSize.Unknown);
-            SetMetadata((int) size, IntSizeMask, IntSizeShift);
+            SetMetadata((int)size, IntSizeMask, IntSizeShift);
         }
     }
 }

--- a/IonDotnet/Tree/Impl/IonSequence.cs
+++ b/IonDotnet/Tree/Impl/IonSequence.cs
@@ -84,6 +84,8 @@ namespace IonDotnet.Tree.Impl
         {
             ThrowIfLocked();
             ThrowIfNull();
+            if (NullFlagOn())
+                return false;
 
             Debug.Assert(_children?.Contains(item) == true);
             _children.Remove(item);

--- a/IonDotnet/Tree/Impl/IonSequence.cs
+++ b/IonDotnet/Tree/Impl/IonSequence.cs
@@ -70,12 +70,8 @@ namespace IonDotnet.Tree.Impl
             ThrowIfNull();
             if (item is null)
                 throw new ArgumentNullException(nameof(item));
-            //? Remove
-            //if (item.Container != null)
-            //    throw new ContainedValueException(item);
 
             _children.Add(item);
-            //item.Container = this; //?
         }
 
         /// <inheritdoc />
@@ -88,12 +84,9 @@ namespace IonDotnet.Tree.Impl
         {
             ThrowIfLocked();
             ThrowIfNull();
-            //?if (NullFlagOn() || item?.Container != this)
-            //    return false;
 
             Debug.Assert(_children?.Contains(item) == true);
             _children.Remove(item);
-            //item.Container = null; //?
             return true;
         }
 
@@ -103,13 +96,9 @@ namespace IonDotnet.Tree.Impl
             ThrowIfNull();
             if (item == null)
                 throw new ArgumentNullException(nameof(item));
-            //? Remove
-            //if (item.Container != null)
-            //    throw new ContainedValueException(item);
-
+            
             //this will check range
             _children.Insert(index, item);
-            //item.Container = this; //?
         }
 
         public override void RemoveAt(int index)
@@ -167,24 +156,17 @@ namespace IonDotnet.Tree.Impl
             {
                 _children = new List<IIonValue>();
             }
-
-            //foreach (var child in _children) //?
-            //{
-            //    child.Container = null;
-            //}
-
+            
             NullFlagOn(false);
             _children.Clear();
         }
 
         public override bool Contains(IIonValue item)
         {
-            //? _children.Contains(item);
             if (NullFlagOn() || item == null)
                 return false;
 
             return _children.Contains(item);
-            //return item.Container == this;
         }
 
         public IIonValue this[int index]

--- a/IonDotnet/Tree/Impl/IonSequence.cs
+++ b/IonDotnet/Tree/Impl/IonSequence.cs
@@ -70,11 +70,12 @@ namespace IonDotnet.Tree.Impl
             ThrowIfNull();
             if (item is null)
                 throw new ArgumentNullException(nameof(item));
-            if (item.Container != null)
-                throw new ContainedValueException(item);
+            //? Remove
+            //if (item.Container != null)
+            //    throw new ContainedValueException(item);
 
             _children.Add(item);
-            item.Container = this;
+            //item.Container = this; //?
         }
 
         /// <inheritdoc />
@@ -87,12 +88,12 @@ namespace IonDotnet.Tree.Impl
         {
             ThrowIfLocked();
             ThrowIfNull();
-            if (NullFlagOn() || item?.Container != this)
-                return false;
+            //?if (NullFlagOn() || item?.Container != this)
+            //    return false;
 
             Debug.Assert(_children?.Contains(item) == true);
             _children.Remove(item);
-            item.Container = null;
+            //item.Container = null; //?
             return true;
         }
 
@@ -102,12 +103,13 @@ namespace IonDotnet.Tree.Impl
             ThrowIfNull();
             if (item == null)
                 throw new ArgumentNullException(nameof(item));
-            if (item.Container != null)
-                throw new ContainedValueException(item);
+            //? Remove
+            //if (item.Container != null)
+            //    throw new ContainedValueException(item);
 
             //this will check range
             _children.Insert(index, item);
-            item.Container = this;
+            //item.Container = this; //?
         }
 
         public override void RemoveAt(int index)
@@ -166,10 +168,10 @@ namespace IonDotnet.Tree.Impl
                 _children = new List<IIonValue>();
             }
 
-            foreach (var child in _children)
-            {
-                child.Container = null;
-            }
+            //foreach (var child in _children) //?
+            //{
+            //    child.Container = null;
+            //}
 
             NullFlagOn(false);
             _children.Clear();
@@ -177,10 +179,12 @@ namespace IonDotnet.Tree.Impl
 
         public override bool Contains(IIonValue item)
         {
+            //? _children.Contains(item);
             if (NullFlagOn() || item == null)
                 return false;
 
-            return item.Container == this;
+            return _children.Contains(item);
+            //return item.Container == this;
         }
 
         public IIonValue this[int index]

--- a/IonDotnet/Tree/Impl/IonStruct.cs
+++ b/IonDotnet/Tree/Impl/IonStruct.cs
@@ -95,11 +95,12 @@ namespace IonDotnet.Tree.Impl
                 throw new ArgumentNullException(nameof(fieldName));
             ThrowIfLocked();
             ThrowIfNull();
-            if (value.Container != null)
-                throw new ContainedValueException(value);
+            //? Remove
+            //if (value.Container != null)
+            //    throw new ContainedValueException(value);
 
             value.FieldNameSymbol = new SymbolToken(fieldName, SymbolToken.UnknownSid);
-            value.Container = this;
+            //value.Container = this;//?
             _values.Add(value);
         }
 
@@ -115,11 +116,12 @@ namespace IonDotnet.Tree.Impl
                 throw new ArgumentException("symbol has no text or sid", nameof(symbol));
             ThrowIfLocked();
             ThrowIfNull();
-            if (value.Container != null)
-                throw new ContainedValueException(value);
+            //? Remove
+            //if (value.Container != null)
+            //    throw new ContainedValueException(value);
 
             value.FieldNameSymbol = symbol;
-            value.Container = this;
+            //value.Container = this;//?
             _values.Add(value);
         }
 
@@ -130,21 +132,23 @@ namespace IonDotnet.Tree.Impl
                 _values = new List<IIonValue>();
 
             NullFlagOn(false);
-            foreach (var v in _values)
-            {
-                v.Container = null;
-            }
+            //foreach (var v in _values) //?
+            //{
+            //    v.Container = null;
+            //}
 
             _values.Clear();
         }
 
         public override bool Contains(IIonValue item)
         {
+            //? _values.Contains(item);
             if (NullFlagOn() || item is null)
                 return false;
 
             Debug.Assert(_values != null);
-            return item.Container == this;
+            return _values.Contains(item);
+            //return item.Container == this;
         }
 
         public override IEnumerator<IIonValue> GetEnumerator()
@@ -170,12 +174,12 @@ namespace IonDotnet.Tree.Impl
             if (item == null)
                 throw new ArgumentNullException(nameof(item));
 
-            if (item.Container != this)
-                return false;
+            //if (item.Container != this)
+            //    return false;
 
             Debug.Assert(item.FieldNameSymbol != default && _values != null);
             _values.Remove(item);
-            item.Container = null;
+            //item.Container = null;//?
             item.FieldNameSymbol = default;
             return true;
         }
@@ -206,13 +210,14 @@ namespace IonDotnet.Tree.Impl
                     throw new ArgumentNullException(nameof(fieldName));
                 ThrowIfLocked();
                 ThrowIfNull();
-                if (value.Container != null)
-                    throw new ContainedValueException();
+                //? Remove
+                //if (value.Container != null)
+                //    throw new ContainedValueException();
 
                 RemoveUnsafe(fieldName);
 
                 value.FieldNameSymbol = new SymbolToken(fieldName, SymbolToken.UnknownSid);
-                value.Container = this;
+                //value.Container = this;//?
                 _values.Add(value);
             }
         }
@@ -253,7 +258,7 @@ namespace IonDotnet.Tree.Impl
                 var match = v.FieldNameSymbol.Text == fieldName;
                 if (match)
                 {
-                    v.Container = null;
+                    //v.Container = null;//?
                     v.FieldNameSymbol = default;
                 }
 

--- a/IonDotnet/Tree/Impl/IonStruct.cs
+++ b/IonDotnet/Tree/Impl/IonStruct.cs
@@ -88,19 +88,14 @@ namespace IonDotnet.Tree.Impl
         /// <param name="fieldName">Field name</param>
         /// <param name="value">Ion value to add.</param>
         /// <exception cref="ArgumentNullException">When field name is null.</exception>
-        /// <exception cref="ContainedValueException">If the value is already child of a container.</exception>
         public void Add(string fieldName, IIonValue value)
         {
             if (fieldName is null)
                 throw new ArgumentNullException(nameof(fieldName));
             ThrowIfLocked();
             ThrowIfNull();
-            //? Remove
-            //if (value.Container != null)
-            //    throw new ContainedValueException(value);
 
             value.FieldNameSymbol = new SymbolToken(fieldName, SymbolToken.UnknownSid);
-            //value.Container = this;//?
             _values.Add(value);
         }
 
@@ -116,12 +111,8 @@ namespace IonDotnet.Tree.Impl
                 throw new ArgumentException("symbol has no text or sid", nameof(symbol));
             ThrowIfLocked();
             ThrowIfNull();
-            //? Remove
-            //if (value.Container != null)
-            //    throw new ContainedValueException(value);
 
             value.FieldNameSymbol = symbol;
-            //value.Container = this;//?
             _values.Add(value);
         }
 
@@ -132,23 +123,16 @@ namespace IonDotnet.Tree.Impl
                 _values = new List<IIonValue>();
 
             NullFlagOn(false);
-            //foreach (var v in _values) //?
-            //{
-            //    v.Container = null;
-            //}
-
             _values.Clear();
         }
 
         public override bool Contains(IIonValue item)
         {
-            //? _values.Contains(item);
             if (NullFlagOn() || item is null)
                 return false;
 
             Debug.Assert(_values != null);
             return _values.Contains(item);
-            //return item.Container == this;
         }
 
         public override IEnumerator<IIonValue> GetEnumerator()
@@ -174,12 +158,8 @@ namespace IonDotnet.Tree.Impl
             if (item == null)
                 throw new ArgumentNullException(nameof(item));
 
-            //if (item.Container != this)
-            //    return false;
-
             Debug.Assert(item.FieldNameSymbol != default && _values != null);
             _values.Remove(item);
-            //item.Container = null;//?
             item.FieldNameSymbol = default;
             return true;
         }
@@ -194,7 +174,6 @@ namespace IonDotnet.Tree.Impl
         /// </summary>
         /// <param name="fieldName">Field name.</param>
         /// <exception cref="ArgumentNullException">When field name is null.</exception>
-        /// <exception cref="ContainedValueException">If the value being set is already contained in another container.</exception>
         public IIonValue this[string fieldName]
         {
             get
@@ -210,14 +189,10 @@ namespace IonDotnet.Tree.Impl
                     throw new ArgumentNullException(nameof(fieldName));
                 ThrowIfLocked();
                 ThrowIfNull();
-                //? Remove
-                //if (value.Container != null)
-                //    throw new ContainedValueException();
 
                 RemoveUnsafe(fieldName);
 
                 value.FieldNameSymbol = new SymbolToken(fieldName, SymbolToken.UnknownSid);
-                //value.Container = this;//?
                 _values.Add(value);
             }
         }
@@ -258,7 +233,6 @@ namespace IonDotnet.Tree.Impl
                 var match = v.FieldNameSymbol.Text == fieldName;
                 if (match)
                 {
-                    //v.Container = null;//?
                     v.FieldNameSymbol = default;
                 }
 

--- a/IonDotnet/Tree/Impl/IonSymbol.cs
+++ b/IonDotnet/Tree/Impl/IonSymbol.cs
@@ -56,22 +56,11 @@ namespace IonDotnet.Tree.Impl
         public override string StringValue
         {
             get => base.StringValue;
-            set
-            {
-                base.StringValue = value;
-                _sid = SymbolToken.UnknownSid;
-            }
         }
 
         public override SymbolToken SymbolValue
         {
             get => new SymbolToken(StringVal, _sid, _importLocation);
-            set
-            {
-                StringValue = value.Text;
-                _sid = value.Sid;
-                _importLocation = value.ImportLocation;
-            }
         }
     }
 }

--- a/IonDotnet/Tree/Impl/IonText.cs
+++ b/IonDotnet/Tree/Impl/IonText.cs
@@ -19,12 +19,6 @@ namespace IonDotnet.Tree.Impl
         public override string StringValue
         {
             get => StringVal;
-            set
-            {
-                ThrowIfLocked();
-                NullFlagOn(value is null);
-                StringVal = value;
-            }
         }
 
         public override void MakeNull()

--- a/IonDotnet/Tree/Impl/IonTimestamp.cs
+++ b/IonDotnet/Tree/Impl/IonTimestamp.cs
@@ -51,11 +51,6 @@ namespace IonDotnet.Tree.Impl
                 ThrowIfNull();
                 return _timestamp;
             }
-            set
-            {
-                ThrowIfLocked();
-                _timestamp = value;
-            }
         }
 
         public override IonType Type() => IonType.Timestamp;

--- a/IonDotnet/Tree/Impl/IonValue.cs
+++ b/IonDotnet/Tree/Impl/IonValue.cs
@@ -198,7 +198,8 @@ namespace IonDotnet.Tree.Impl
         /// <summary>
         /// The container of this value, or null if this is not part of one.
         /// </summary>
-        public virtual IIonContainer Container { get; set; }
+        //? public virtual IIonContainer Container { get; set; } //?
+        public virtual IIonValue Children { get; } //?
 
         /// <summary>
         /// Get this value's user type annotations.

--- a/IonDotnet/Tree/Impl/IonValue.cs
+++ b/IonDotnet/Tree/Impl/IonValue.cs
@@ -196,12 +196,6 @@ namespace IonDotnet.Tree.Impl
         }
 
         /// <summary>
-        /// The container of this value, or null if this is not part of one.
-        /// </summary>
-        //? public virtual IIonContainer Container { get; set; } //?
-        public virtual IIonValue Children { get; } //?
-
-        /// <summary>
         /// Get this value's user type annotations.
         /// </summary>
         /// <returns>Read-only collection of type annotations.</returns>
@@ -361,12 +355,10 @@ namespace IonDotnet.Tree.Impl
         public virtual decimal DecimalValue
         {
             get => throw new InvalidOperationException(GetErrorMessage());
-            set => throw new InvalidOperationException(GetErrorMessage());
         }
         public virtual BigDecimal BigDecimalValue
         {
             get => throw new InvalidOperationException(GetErrorMessage());
-            set => throw new InvalidOperationException(GetErrorMessage());
         }
 
         // Applicable to IonContainer
@@ -376,7 +368,6 @@ namespace IonDotnet.Tree.Impl
         public virtual string StringValue
         {
             get => throw new InvalidOperationException(GetErrorMessage());
-            set => throw new InvalidOperationException(GetErrorMessage());
         }
 
         // Applicable to IonInt
@@ -385,47 +376,40 @@ namespace IonDotnet.Tree.Impl
         public virtual BigInteger BigIntegerValue
         {
             get => throw new InvalidOperationException(GetErrorMessage());
-            set => throw new InvalidOperationException(GetErrorMessage());
         }
 
         public virtual int IntValue
         {
             get => throw new InvalidOperationException(GetErrorMessage());
-            set => throw new InvalidOperationException(GetErrorMessage());
         }
 
         public virtual long LongValue
         {
             get => throw new InvalidOperationException(GetErrorMessage());
-            set => throw new InvalidOperationException(GetErrorMessage());
         }
 
         // Applicable to IonSymbol
         public virtual SymbolToken SymbolValue
         {
             get => throw new InvalidOperationException(GetErrorMessage());
-            set => throw new InvalidOperationException(GetErrorMessage());
         }
 
         // Applicable to IonBool
         public virtual bool BoolValue
         {
             get => throw new InvalidOperationException(GetErrorMessage());
-            set => throw new InvalidOperationException(GetErrorMessage());
         }
 
         // Applicable to IonFloat
         public virtual double DoubleValue
         {
             get => throw new InvalidOperationException(GetErrorMessage());
-            set => throw new InvalidOperationException(GetErrorMessage());
         }
 
         // Applicable to IonTimestamp
         public virtual Timestamp TimestampValue
         {
             get => throw new InvalidOperationException(GetErrorMessage());
-            set => throw new InvalidOperationException(GetErrorMessage());
         }
 
         public string ToPrettyString()

--- a/IonDotnet/Tree/Impl/IonValue.cs
+++ b/IonDotnet/Tree/Impl/IonValue.cs
@@ -516,7 +516,7 @@ namespace IonDotnet.Tree.Impl
 
         public virtual IonType Type()
         {
-            throw new InvalidOperationException(GetErrorMessage());
+            throw new InvalidOperationException("This operation is not supported for this IonType}");
         }
     }
 }


### PR DESCRIPTION
*Issue #52*

*Description of changes:*
- Removed ```IonValue.Container```
- Removed setters for scalar types in ```IonValue``` and its derived classes
- Removed ```ContainedValueException```
