### PR TITLE
Update Reader to set CurrentType to IonType.None

### DIFF
--- a/IonDotnet.Tests/Internals/BinaryReaderTest.cs
+++ b/IonDotnet.Tests/Internals/BinaryReaderTest.cs
@@ -58,6 +58,17 @@ namespace IonDotnet.Tests.Internals
         }
 
         [TestMethod]
+        [DataRow(new byte[] { 0xE0, 0x01, 0x00, 0xEA, 0x11 })]
+        public void TestCurrentType(byte[] data)
+        {
+            var reader = new UserBinaryReader(new MemoryStream(data));
+            Assert.AreEqual(IonType.None, reader.CurrentType);
+
+            reader.MoveNext();
+            Assert.AreEqual(IonType.Bool, reader.CurrentType);
+        }
+
+        [TestMethod]
         public void OneBoolInStruct()
         {
             //simple datagram: {yolo:true}

--- a/IonDotnet.Tests/Internals/BinaryReaderTest.cs
+++ b/IonDotnet.Tests/Internals/BinaryReaderTest.cs
@@ -58,10 +58,9 @@ namespace IonDotnet.Tests.Internals
         }
 
         [TestMethod]
-        [DataRow(new byte[] { 0xE0, 0x01, 0x00, 0xEA, 0x11 })]
-        public void TestCurrentType(byte[] data)
+        public void TestCurrentType()
         {
-            var reader = new UserBinaryReader(new MemoryStream(data));
+            var reader = new UserBinaryReader(new MemoryStream(new byte[] { 0xE0, 0x01, 0x00, 0xEA, 0x11 }));
             Assert.AreEqual(IonType.None, reader.CurrentType);
 
             reader.MoveNext();

--- a/IonDotnet.Tests/Internals/TextReaderTest.cs
+++ b/IonDotnet.Tests/Internals/TextReaderTest.cs
@@ -71,6 +71,16 @@ namespace IonDotnet.Tests.Internals
             ReaderTestCommon.SingleNumber(reader, value);
         }
 
+        public void CurrentType()
+        {
+            var bin = Encoding.UTF8.GetBytes("test");
+            var reader = new UserTextReader(new MemoryStream(bin));
+            Assert.AreEqual(IonType.None, reader.CurrentType);
+
+            reader.MoveNext();
+            Assert.AreEqual(IonType.String, reader.CurrentType);
+        }
+
         [TestMethod]
         public void OneBoolInStruct()
         {

--- a/IonDotnet.Tests/Internals/TextReaderTest.cs
+++ b/IonDotnet.Tests/Internals/TextReaderTest.cs
@@ -71,14 +71,15 @@ namespace IonDotnet.Tests.Internals
             ReaderTestCommon.SingleNumber(reader, value);
         }
 
+        [TestMethod]
         public void CurrentType()
         {
-            var bin = Encoding.UTF8.GetBytes("test");
+            var bin = Encoding.UTF8.GetBytes("true");
             var reader = new UserTextReader(new MemoryStream(bin));
             Assert.AreEqual(IonType.None, reader.CurrentType);
 
             reader.MoveNext();
-            Assert.AreEqual(IonType.String, reader.CurrentType);
+            Assert.AreEqual(IonType.Bool, reader.CurrentType);
         }
 
         [TestMethod]

--- a/IonDotnet.Tests/Internals/TreeReaderTest.cs
+++ b/IonDotnet.Tests/Internals/TreeReaderTest.cs
@@ -87,6 +87,17 @@ namespace IonDotnet.Tests.Internals
         }
 
         [TestMethod]
+        public void CurrentTypeTest()
+        {
+            var value = _ionValueFactory.NewBool(true);
+            var reader = new UserTreeReader(value);
+            Assert.AreEqual(IonType.None, reader.CurrentType);
+
+            reader.MoveNext();
+            Assert.AreEqual(IonType.Bool, reader.CurrentType);
+        }
+
+        [TestMethod]
         public void ListOfIntsTest()
         {
             //Must be: [123,456,789]

--- a/IonDotnet/Internals/Binary/RawBinaryReader.cs
+++ b/IonDotnet/Internals/Binary/RawBinaryReader.cs
@@ -81,6 +81,7 @@ namespace IonDotnet.Internals.Binary
             _state = State.BeforeTid;
             _eof = false;
             _moveNextNeeded = true;
+            _valueType = IonType.None;
             _valueIsNull = false;
             _valueIsTrue = false;
             IsInStruct = false;

--- a/IonDotnet/Internals/Tree/SystemTreeReader.cs
+++ b/IonDotnet/Internals/Tree/SystemTreeReader.cs
@@ -41,7 +41,7 @@ namespace IonDotnet.Internals.Tree
 
         public int CurrentDepth => _top/2;
 
-        public IonType CurrentType => _current.Type();
+        public IonType CurrentType => (_current == null) ? IonType.None : _current.Type();
 
         public string CurrentFieldName => _current.FieldNameSymbol.Text;
 


### PR DESCRIPTION
Fixed a bug in the SystemTreeReader.cs where the _current field (IIonValue) was initialized to null and if a user called the CurrentType property, it would throw NullReferenceException. Added a null check in CurrentType to return IonType.None.

Also initialized _valueType property to IonType.None in RawBinaryReader.cs because it was being set to IonType.Null.